### PR TITLE
Fix: Fix send_json cannot send message with some specific characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,9 @@ impl WindowHandler {
     pub fn send_json(&self, json: Value) -> Result<(), String> {
         // TODO: proper error handling
         if let Ok(json_str) = serde_json::to_string(&json) {
+            let json_str_quoted = serde_json::to_string(&json_str);
             self.webview
-                .evaluate_script(&format!("onPluginMessageInternal(`{}`);", json_str))
+                .evaluate_script(&format!("onPluginMessageInternal({});", json_str_quoted))
                 .unwrap();
             return Ok(());
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl WindowHandler {
     pub fn send_json(&self, json: Value) -> Result<(), String> {
         // TODO: proper error handling
         if let Ok(json_str) = serde_json::to_string(&json) {
-            let json_str_quoted = serde_json::to_string(&json_str);
+            let json_str_quoted = serde_json::to_string(&json_str).expect("Should not fail: the value is always string");
             self.webview
                 .evaluate_script(&format!("onPluginMessageInternal({});", json_str_quoted))
                 .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,16 +135,13 @@ impl WindowHandler {
     }
 
     pub fn send_json(&self, json: Value) -> Result<(), String> {
-        // TODO: proper error handling
-        if let Ok(json_str) = serde_json::to_string(&json) {
-            let json_str_quoted = serde_json::to_string(&json_str).expect("Should not fail: the value is always string");
-            self.webview
-                .evaluate_script(&format!("onPluginMessageInternal({});", json_str_quoted))
-                .unwrap();
-            return Ok(());
-        } else {
-            return Err("Can't convert JSON to string.".to_owned());
-        }
+        let json_str = json.to_string();
+        let json_str_quoted =
+            serde_json::to_string(&json_str).expect("Should not fail: the value is always string");
+        self.webview
+            .evaluate_script(&format!("onPluginMessageInternal({});", json_str_quoted))
+            .unwrap();
+        return Ok(());
     }
 
     pub fn next_event(&self) -> Result<Value, crossbeam::channel::TryRecvError> {


### PR DESCRIPTION
This library couldn't send messages with some specific characters such as:
- backquotes
- `\"` sequence

This PR fixes the problem by changing the way to send json.
While original used backquotes to send JSON string, this PR uses serde_json twice to do so.