### PR TITLE
Rollback to wry 0.35.1 fix issue #16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git" }
 parking_lot = "0.12.1"
 serde_json = "1.0"
-wry = { version = "0.35.2" }
+wry = { version = "0.35.1" }
 baseview = { git = "https://github.com/RustAudio/baseview" }
 raw-window-handle = "0.5"
 crossbeam = "0.8.2"


### PR DESCRIPTION
Gain example crashes on macos
this is a temp work around see https://github.com/httnn/nih-plug-webview/issues/16#issuecomment-2571337978 ... to fully update wry, there's more work to be done regarding some breaking changes at wry v0.36.0 https://github.com/tauri-apps/wry/releases/tag/wry-v0.36.0